### PR TITLE
Update Mill API to 0.11.0-M8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
         targets:
           - __.publishLocal $(pwd)/testRepo
           - "main[_].__.test"
-          - "itest[0.11.0-M7].test"
+          - "itest[0.11.0-M8].test"
           - "itest[0.10.11].test"
           - "itest[0.10.3].test"
           - "itest[0.10.0].test"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        java-version: [8, 11]
+        java-version: [8, 11, 17]
         targets:
           - __.publishLocal $(pwd)/testRepo
           - "main[_].__.test"
@@ -52,7 +52,7 @@ jobs:
       - name: Upload scoverage reports to codecov.io
         uses: codecov/codecov-action@v3
         with:
-          files: ./out/api/0.11.0-M6/scoverage/xmlReport.dest/scoverage.xml,./out/api/0.10/scoverage/xmlReport.dest/scoverage.xml,./out/api/0.9/scoverage/xmlReport.dest/scoverage.xml,./out/api/0.7/scoverage/xmlReport.dest/scoverage.xml,./out/worker/0.11.0-M6/scoverage/xmlReport.dest/scoverage.xml,./out/worker/0.10/scoverage/xmlReport.dest/scoverage.xml,./out/worker/0.9/scoverage/xmlReport.dest/scoverage.xml,./out/worker/0.7/scoverage/xmlReport.dest/scoverage.xml,./out/main/0.11.0-M6/scoverage/xmlReport.dest/scoverage.xml,./out/main/0.10/scoverage/xmlReport.dest/scoverage.xml,./out/main/0.9/scoverage/xmlReport.dest/scoverage.xml,./out/main/0.7/scoverage/xmlReport.dest/scoverage.xml
+          files: ./out/**/scoverage/xmlReport.dest/scoverage.xml
         continue-on-error: true
 
   publish:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,17 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '**'
+  pull_request:
+
+# cancel older runs of a pull request;
+# this will not cancel anything for normal git pushes
+concurrency:
+  group: cancel-old-pr-runs-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 
 jobs: 
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Upload scoverage reports to codecov.io
         uses: codecov/codecov-action@v3
         with:
-          files: ./out/**/scoverage/xmlReport.dest/scoverage.xml
+          files: ./out/api/0.11.0-M8/scoverage/xmlReport.dest/scoverage.xml,./out/api/0.10/scoverage/xmlReport.dest/scoverage.xml,./out/api/0.9/scoverage/xmlReport.dest/scoverage.xml,./out/api/0.7/scoverage/xmlReport.dest/scoverage.xml,./out/worker/0.11.0-M8/scoverage/xmlReport.dest/scoverage.xml,./out/worker/0.10/scoverage/xmlReport.dest/scoverage.xml,./out/worker/0.9/scoverage/xmlReport.dest/scoverage.xml,./out/worker/0.7/scoverage/xmlReport.dest/scoverage.xml,./out/main/0.11.0-M8/scoverage/xmlReport.dest/scoverage.xml,./out/main/0.10/scoverage/xmlReport.dest/scoverage.xml,./out/main/0.9/scoverage/xmlReport.dest/scoverage.xml,./out/main/0.7/scoverage/xmlReport.dest/scoverage.xml
         continue-on-error: true
 
   publish:

--- a/build.sc
+++ b/build.sc
@@ -35,7 +35,7 @@ trait Deps {
 }
 object Deps_0_11 extends Deps {
   override def millVersion = millPlatform // only valid for exact milestone versions
-  override def millPlatform = "0.11.0-M7" // needs to be an exact milestone version
+  override def millPlatform = "0.11.0-M8" // needs to be an exact milestone version
   override def scalaVersion = "2.13.10"
   // keep in sync with .github/workflows/build.yml
   override def testWithMill = Seq(millVersion)

--- a/itest/src/hello-world-kotlin-1.0/build.sc
+++ b/itest/src/hello-world-kotlin-1.0/build.sc
@@ -1,5 +1,5 @@
-import $exec.plugins
-import $exec.shared
+import $file.plugins
+import $file.shared
 
 import mill._
 import mill.scalalib._

--- a/itest/src/hello-world-kotlin-1.1/build.sc
+++ b/itest/src/hello-world-kotlin-1.1/build.sc
@@ -1,5 +1,5 @@
-import $exec.plugins
-import $exec.shared
+import $file.plugins
+import $file.shared
 
 import mill._
 import mill.scalalib._

--- a/itest/src/hello-world-kotlin-1.2/build.sc
+++ b/itest/src/hello-world-kotlin-1.2/build.sc
@@ -1,5 +1,5 @@
-import $exec.plugins
-import $exec.shared
+import $file.plugins
+import $file.shared
 
 import mill._
 import mill.scalalib._

--- a/itest/src/hello-world-kotlin-1.3/build.sc
+++ b/itest/src/hello-world-kotlin-1.3/build.sc
@@ -1,5 +1,5 @@
-import $exec.plugins
-import $exec.shared
+import $file.plugins
+import $file.shared
 
 import mill._
 import mill.scalalib._

--- a/itest/src/hello-world-kotlin-1.4/build.sc
+++ b/itest/src/hello-world-kotlin-1.4/build.sc
@@ -1,5 +1,5 @@
-import $exec.plugins
-import $exec.shared
+import $file.plugins
+import $file.shared
 
 import mill._
 import mill.scalalib._

--- a/itest/src/mixed-code-hello-world-kotlin-1.2/build.sc
+++ b/itest/src/mixed-code-hello-world-kotlin-1.2/build.sc
@@ -1,5 +1,5 @@
-import $exec.plugins
-import $exec.shared
+import $file.plugins
+import $file.shared
 
 import mill._
 import mill.scalalib._

--- a/itest/src/mixed-code-hello-world-kotlin-1.4/build.sc
+++ b/itest/src/mixed-code-hello-world-kotlin-1.4/build.sc
@@ -1,5 +1,5 @@
-import $exec.plugins
-import $exec.shared
+import $file.plugins
+import $file.shared
 
 import mill._
 import mill.scalalib._


### PR DESCRIPTION
Needed to adapt to test buildfiles as `import $exec` is no longer supported.
