### PR TITLE
Introduce a shared worker cache

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -80,7 +80,7 @@ trait MillKotlinModule extends PublishModule with ScoverageModule with Cross.Mod
       else Seq("-source", "1.8", "-target", "1.8")
     release ++ Seq("-encoding", "UTF-8", "-deprecation")
   }
-  override def scalacOptions = Seq("-target:jvm-1.8", "-encoding", "UTF-8", "-deprecation")
+  override def scalacOptions = Seq("-release:8", "-encoding", "UTF-8", "-deprecation")
 
   override def scoverageVersion = deps.scoverageVersion
 

--- a/main/src-0.10/de/tobiasroeser/mill/kotlin/KotlinModulePlatform.scala
+++ b/main/src-0.10/de/tobiasroeser/mill/kotlin/KotlinModulePlatform.scala
@@ -14,6 +14,8 @@ trait KotlinModulePlatform extends JavaModule {
   protected type ModuleRef[T] = Function0[T]
   protected def zincWorkerRef: ModuleRef[ZincWorkerModule] = () => zincWorker
 
+  protected def kotlinWorkerRef: ModuleRef[KotlinWorkerModule] = () => KotlinWorkerModule
+
   def kotlinCompilerIvyDeps: T[Agg[Dep]]
 
   /**

--- a/main/src-0.11/de/tobiasroeser/mill/kotlin/KotlinModulePlatform.scala
+++ b/main/src-0.11/de/tobiasroeser/mill/kotlin/KotlinModulePlatform.scala
@@ -1,7 +1,7 @@
 package de.tobiasroeser.mill.kotlin
 
 import mill.{Agg, T}
-import mill.api.{CompileProblemReporter, PathRef, Result}
+import mill.api.{PathRef, Result}
 import mill.define.{ModuleRef, Task}
 import mill.scalalib.api.{CompilationResult, ZincWorkerApi}
 import mill.scalalib.{Dep, JavaModule, ZincWorkerModule}
@@ -11,6 +11,8 @@ trait KotlinModulePlatform extends JavaModule {
   type CompileProblemReporter = mill.api.CompileProblemReporter
 
   protected def zincWorkerRef: ModuleRef[ZincWorkerModule] = zincWorker
+
+  protected def kotlinWorkerRef: ModuleRef[KotlinWorkerModule] = ModuleRef(KotlinWorkerModule)
 
   def kotlinCompilerIvyDeps: T[Agg[Dep]]
 

--- a/main/src-0.9-/de/tobiasroeser/mill/kotlin/KotlinModulePlatform.scala
+++ b/main/src-0.9-/de/tobiasroeser/mill/kotlin/KotlinModulePlatform.scala
@@ -16,6 +16,8 @@ trait KotlinModulePlatform extends JavaModule {
   protected type ModuleRef[T] = Function0[T]
   protected def zincWorkerRef: ModuleRef[ZincWorkerModule] = () => zincWorker
 
+  protected def kotlinWorkerRef: ModuleRef[KotlinWorkerModule] = () => KotlinWorkerModule
+
   def kotlinCompilerIvyDeps: T[Agg[Dep]]
 
   /**

--- a/main/src/de/tobiasroeser/mill/kotlin/KotlinWorkerManager.scala
+++ b/main/src/de/tobiasroeser/mill/kotlin/KotlinWorkerManager.scala
@@ -1,0 +1,7 @@
+package de.tobiasroeser.mill.kotlin
+
+import mill.api.{Ctx, PathRef}
+
+trait KotlinWorkerManager {
+  def get(toolsClasspath: Seq[PathRef])(implicit ctx: Ctx): KotlinWorker
+}

--- a/main/src/de/tobiasroeser/mill/kotlin/KotlinWorkerManagerImpl.scala
+++ b/main/src/de/tobiasroeser/mill/kotlin/KotlinWorkerManagerImpl.scala
@@ -1,0 +1,64 @@
+package de.tobiasroeser.mill.kotlin
+
+import mill.PathRef
+import mill.api.{Ctx, PathRef}
+
+import java.io.PrintStream
+import java.net.{URL, URLClassLoader}
+
+class KotlinWorkerManagerImpl(ctx: Ctx) extends KotlinWorkerManager with AutoCloseable {
+
+  private[this] var workerCache: Map[Seq[PathRef], (KotlinWorker, Int)] = Map.empty
+
+  override def get(toolsClasspath: Seq[PathRef])(implicit ctx: Ctx): KotlinWorker = {
+    val toolsCp = toolsClasspath.distinct
+    val (worker, count) = workerCache.get(toolsCp) match {
+      case Some((w, count)) =>
+        ctx.log.debug(s"Reusing existing AspectjWorker for classpath: ${toolsCp}")
+        w -> count
+      case None =>
+        ctx.log.debug(s"Creating Classloader with classpath: [${toolsCp}]")
+        val classLoader = new URLClassLoader(
+          toolsCp.map(_.path.toNIO.toUri().toURL()).toArray[URL],
+          getClass().getClassLoader()
+        )
+
+        val className =
+          classOf[KotlinWorker].getPackage().getName() + ".impl." + classOf[KotlinWorker].getSimpleName() + "Impl"
+        ctx.log.debug(s"Creating ${className} from classpath: ${toolsCp}")
+        val impl = classLoader.loadClass(className)
+        val worker = impl.getConstructor().newInstance().asInstanceOf[KotlinWorker]
+        if (worker.getClass().getClassLoader() != classLoader) {
+          ctx.log.error(
+            """Worker not loaded from worker classloader.
+              |You should not add the mill-kotlin-worker JAR to the mill build classpath""".stripMargin
+          )
+        }
+        if (worker.getClass().getClassLoader() == classOf[KotlinWorker].getClassLoader()) {
+          ctx.log.error("Worker classloader used to load interface and implementation")
+        }
+        worker -> 0
+    }
+    workerCache += toolsCp -> (worker -> (1 + count))
+    ctx.log.debug(stats())
+    worker
+  }
+
+  def stats(): String = {
+    s"""Cache statistics of ${this.toString()}:
+       |${
+        workerCache.map { case (cp, (worker, count)) =>
+          s"""- worker: ${worker.toString()}
+             |  used: ${count}
+             |""".stripMargin
+        }.mkString
+      }""".stripMargin
+  }
+
+  override def close(): Unit = {
+    ctx.log.debug(stats())
+
+    // We drop cached worker instances
+    workerCache = Map.empty
+  }
+}

--- a/main/src/de/tobiasroeser/mill/kotlin/KotlinWorkerModule.scala
+++ b/main/src/de/tobiasroeser/mill/kotlin/KotlinWorkerModule.scala
@@ -1,0 +1,14 @@
+package de.tobiasroeser.mill.kotlin
+
+import mill.T
+import mill.define.{Discover, ExternalModule, Module, Worker}
+
+trait KotlinWorkerModule extends Module {
+  def kotlinWorkerManager: Worker[KotlinWorkerManager] = T.worker {
+   new KotlinWorkerManagerImpl(T.ctx())
+  }
+}
+
+object KotlinWorkerModule extends ExternalModule with KotlinWorkerModule {
+  override def millDiscover: Discover[this.type] = Discover[this.type]
+}


### PR DESCRIPTION
With this change, for module that resolve the same compiler classpath, we share the classloader to profit from speedups due to JITed classes and less memory usage.

When Mill is run in `debug` mode, we also log some statistics about the used cache.